### PR TITLE
Add cross-validated crJSON content sidecars for the validator suite

### DIFF
--- a/contrib/google/assets/avif_valid.avif.crjson
+++ b/contrib/google/assets/avif_valid.avif.crjson
@@ -1,0 +1,55 @@
+{
+  "active_manifest": "urn:c2pa:ce1ea376-3434-60d8-025a-4b63b0327116",
+  "manifests": {
+    "urn:c2pa:ce1ea376-3434-60d8-025a-4b63b0327116": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "4d539d93-d9df-2189-d912-4650045ddbdc",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.bmff.v3",
+          "data": {
+            "exclusions": [
+              {
+                "xpath": "/ftyp"
+              },
+              {
+                "xpath": "/uuid",
+                "data": [
+                  {
+                    "offset": 8,
+                    "value": "2P7D1hsOSDySl1goh37EgQ=="
+                  }
+                ]
+              },
+              {
+                "xpath": "/mfra"
+              },
+              {
+                "xpath": "/free"
+              }
+            ],
+            "alg": "sha256",
+            "hash": "2JOg7G1g5MyLtp8irupmQz9b2u0bifgn5B5fwQagMpI=",
+            "name": "BMFF file hash"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/bmff_hash_mismatch.mp4.crjson
+++ b/contrib/google/assets/bmff_hash_mismatch.mp4.crjson
@@ -1,0 +1,55 @@
+{
+  "active_manifest": "urn:c2pa:21e6b9ef-9f0f-b5cb-ca2a-45fcde8b5af0",
+  "manifests": {
+    "urn:c2pa:21e6b9ef-9f0f-b5cb-ca2a-45fcde8b5af0": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "be118a53-fb0e-6483-cb77-4788b205b6d4",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.bmff.v3",
+          "data": {
+            "exclusions": [
+              {
+                "xpath": "/ftyp"
+              },
+              {
+                "xpath": "/uuid",
+                "data": [
+                  {
+                    "offset": 8,
+                    "value": "2P7D1hsOSDySl1goh37EgQ=="
+                  }
+                ]
+              },
+              {
+                "xpath": "/mfra"
+              },
+              {
+                "xpath": "/free"
+              }
+            ],
+            "alg": "sha256",
+            "hash": "nWaMRPsmbKA0HzgAmRUv71Tifwkj9bPK/tafdPqo7jU=",
+            "name": "BMFF file hash"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/cert_chain_reverse_order.jpg.crjson
+++ b/contrib/google/assets/cert_chain_reverse_order.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:7a73b6e9-0a58-d909-ff4f-43124d51ca3a",
+  "manifests": {
+    "urn:c2pa:7a73b6e9-0a58-d909-ff4f-43124d51ca3a": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "27efb654-8911-3442-2dbc-4c23a19e738a",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1832
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/chain_sub_2010_2014.jpg.crjson
+++ b/contrib/google/assets/chain_sub_2010_2014.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:c6ee8903-42c8-1364-7c60-4cdee367afb5",
+  "manifests": {
+    "urn:c2pa:c6ee8903-42c8-1364-7c60-4cdee367afb5": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "e23893b9-b492-8bf6-a08b-4b1f0e10f19d",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1819
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/claim_cbor_invalid.jpg.crjson
+++ b/contrib/google/assets/claim_cbor_invalid.jpg.crjson
@@ -1,0 +1,38 @@
+{
+  "active_manifest": "urn:c2pa:dad6b642-51ae-05a0-a37f-48d955aa42f2",
+  "manifests": {
+    "urn:c2pa:dad6b642-51ae-05a0-a37f-48d955aa42f2": {
+      "claim_generator_info": [],
+      "format": "",
+      "instance_id": "",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/claim_missing.jpg.crjson
+++ b/contrib/google/assets/claim_missing.jpg.crjson
@@ -1,0 +1,38 @@
+{
+  "active_manifest": "urn:c2pa:71af80e4-4bf3-ca84-109c-4569a80ce5ef",
+  "manifests": {
+    "urn:c2pa:71af80e4-4bf3-ca84-109c-4569a80ce5ef": {
+      "claim_generator_info": [],
+      "format": "",
+      "instance_id": "",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1039
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/claim_multiple.jpg.crjson
+++ b/contrib/google/assets/claim_multiple.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:a81fbcb2-d552-5396-0c06-4e4b0998dd53",
+  "manifests": {
+    "urn:c2pa:a81fbcb2-d552-5396-0c06-4e4b0998dd53": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "1d578266-eb40-9ae3-c2cb-46c6ebc954f2",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1867
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/claim_signer_ca.jpg.crjson
+++ b/contrib/google/assets/claim_signer_ca.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:81b48f72-14f2-a4ad-4a59-430bc8061e59",
+  "manifests": {
+    "urn:c2pa:81b48f72-14f2-a4ad-4a59-430bc8061e59": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "bf238c30-4198-087d-0eb9-47c620d33fd2",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1505
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/claim_signer_key_cert_sign.jpg.crjson
+++ b/contrib/google/assets/claim_signer_key_cert_sign.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:3f0dad67-c128-8f42-b8d6-4ad90d436631",
+  "manifests": {
+    "urn:c2pa:3f0dad67-c128-8f42-b8d6-4ad90d436631": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "226eb17a-67af-c65d-fbd8-480d88f2bf55",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1465
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/data_hash_mismatch.jpg.crjson
+++ b/contrib/google/assets/data_hash_mismatch.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540",
+  "manifests": {
+    "urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "25d69552-1e97-bd6a-104e-49091bab7454",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "EANqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/dng_valid.dng.crjson
+++ b/contrib/google/assets/dng_valid.dng.crjson
@@ -1,0 +1,46 @@
+{
+  "active_manifest": "urn:c2pa:bd5da168-d81f-73b4-8089-42a7c7c9a55c",
+  "manifests": {
+    "urn:c2pa:bd5da168-d81f-73b4-8089-42a7c7c9a55c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "8063aefe-82af-6063-b4eb-4aa7d934aad0",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 18699248,
+                "length": 4
+              },
+              {
+                "start": 18699260,
+                "length": 1480
+              }
+            ],
+            "alg": "sha256",
+            "hash": "ZsOjxSF5FY2ai/VRpq2kj5F++3IQiGUD8Uc71XBbnJg=",
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+            "pad2": "AA=="
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/docx_valid.docx.crjson
+++ b/contrib/google/assets/docx_valid.docx.crjson
@@ -1,0 +1,92 @@
+{
+  "active_manifest": "urn:c2pa:22ac8f9b-013c-808e-f4f7-4dc4ae065918",
+  "manifests": {
+    "urn:c2pa:22ac8f9b-013c-808e-f4f7-4dc4ae065918": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "84359672-b10e-450f-dbd9-4dff4bd63a89",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.collection.data",
+          "data": {
+            "uris": [
+              {
+                "uri": "word/numbering.xml",
+                "hash": "PQc3w8TDJx8mDylI21FcRp2i4bSkdwRDZXrn47KbMTs="
+              },
+              {
+                "uri": "word/settings.xml",
+                "hash": "f3mvC2Rl/6fVAKye7jF9sarcyCfKcy0wWSTDvbojv6k="
+              },
+              {
+                "uri": "word/fontTable.xml",
+                "hash": "lGrrst6YY6foAQjPR1loI6QRXD3m+gXN8ScRcWzuE6M="
+              },
+              {
+                "uri": "word/_rels/fontTable.xml.rels",
+                "hash": "5Z1cPBTzI8BXMstopVoR0hmHH8Tfd4ZNh2DnEfA43WQ="
+              },
+              {
+                "uri": "word/styles.xml",
+                "hash": "Jd1aTDebfGNBHvdYOHlooSN8rYVo5n748EQ+Tj1S0b8="
+              },
+              {
+                "uri": "word/document.xml",
+                "hash": "DUPT/UqdOcCxNZXtdIU4gk4lD8pFOIjmnyHo3lblsZI="
+              },
+              {
+                "uri": "word/_rels/document.xml.rels",
+                "hash": "/jN/Xz21ZgbKE8fHkUh0eE8V1zbrcR/Dj/UsRfecNCQ="
+              },
+              {
+                "uri": "_rels/.rels",
+                "hash": "padt2JHix1/18IOXiKp2xpyUGhay3o0brk6T9QDtetU="
+              },
+              {
+                "uri": "word/theme/theme1.xml",
+                "hash": "BjsocWCEJCkon3QacOOND+UfAe8d3+k/mHQltAUxJ84="
+              },
+              {
+                "uri": "word/fonts/GoogleSans-bold.ttf",
+                "hash": "5Ig6n58OxCNl6yRD7SKi1K4zilx+6yU+euuFo0VE1XY="
+              },
+              {
+                "uri": "word/fonts/GoogleSans-italic.ttf",
+                "hash": "EG/PTm3NjKbT8HJcG1UDd+q1ATzaUbks7sySCsCgFHE="
+              },
+              {
+                "uri": "word/fonts/GoogleSans-boldItalic.ttf",
+                "hash": "zcYeOeDSOPt6+0btIR0NJgnsYGaPw6M7t1ZwR3bdZa4="
+              },
+              {
+                "uri": "word/fonts/GoogleSans-regular.ttf",
+                "hash": "45ukTsY9G25zBYFVDKX+KMxt1WItA3xKgiub5CepwaY="
+              },
+              {
+                "uri": "[Content_Types].xml",
+                "hash": "yHbMAtqKAsl+1nBKgwT2ossL7NMSlTsKIK5ir2J/S60="
+              }
+            ],
+            "alg": "sha256",
+            "zip_central_directory_hash": "HoZxaKWwpyORbLOcgB8fBRNOTPmaBGBCXpwGg/i7+DU="
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/edited_action.jpg.crjson
+++ b/contrib/google/assets/edited_action.jpg.crjson
@@ -1,0 +1,43 @@
+{
+  "active_manifest": "urn:c2pa:629aa2f5-23bc-5534-9a6e-40e828a042ae",
+  "manifests": {
+    "urn:c2pa:629aa2f5-23bc-5534-9a6e-40e828a042ae": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "b23da0e1-36d1-3a27-93cc-47e5b138e2b7",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1383
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created"
+              },
+              {
+                "action": "c2pa.edited"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/eku_any.jpg.crjson
+++ b/contrib/google/assets/eku_any.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:bdbcbc69-60f6-235b-49ca-4fda52d30803",
+  "manifests": {
+    "urn:c2pa:bdbcbc69-60f6-235b-49ca-4fda52d30803": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "cac19ed1-5f2d-c656-37ce-432ec7514a7a",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1457
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/eku_c2pa_any.jpg.crjson
+++ b/contrib/google/assets/eku_c2pa_any.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:db2383ee-16b2-c285-9777-4f6328f3f9c9",
+  "manifests": {
+    "urn:c2pa:db2383ee-16b2-c285-9777-4f6328f3f9c9": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "5f1592b8-7d13-2e0e-0b4e-40a3281b8e13",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1477
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/eku_email.jpg.crjson
+++ b/contrib/google/assets/eku_email.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:51248dae-2484-aba0-aa3c-40060e722098",
+  "manifests": {
+    "urn:c2pa:51248dae-2484-aba0-aa3c-40060e722098": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "fe65939e-bc41-9875-175b-4e4537ee2bf1",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1462
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/eku_multiple.jpg.crjson
+++ b/contrib/google/assets/eku_multiple.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:8ecba03b-3248-f1ad-1290-4a2c3df9e49e",
+  "manifests": {
+    "urn:c2pa:8ecba03b-3248-f1ad-1290-4a2c3df9e49e": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "673ab41a-06c4-0ff8-3a7c-4b6419f9dca2",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1479
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/eku_none.jpg.crjson
+++ b/contrib/google/assets/eku_none.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:d730a9f7-8faa-7df6-59a9-4d9e11718e15",
+  "manifests": {
+    "urn:c2pa:d730a9f7-8faa-7df6-59a9-4d9e11718e15": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "1c0fa840-69f2-7891-4770-4d786cd6168b",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1439
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/flac_valid.flac.crjson
+++ b/contrib/google/assets/flac_valid.flac.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:5867afd0-78af-ade8-77f4-400033121c50",
+  "manifests": {
+    "urn:c2pa:5867afd0-78af-ade8-77f4-400033121c50": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "4d6b8da9-1b13-13c5-2486-47415c6ae1d8",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 63,
+                "length": 1441
+              }
+            ],
+            "alg": "sha256",
+            "hash": "R3LxfHzBkc/ZgZRxHly0JR+At4ib9M34+QRGoUGF5tk=",
+            "pad": "AAAAAAAAAAAAAAAAAA=="
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/gif_valid.gif.crjson
+++ b/contrib/google/assets/gif_valid.gif.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:14808c4e-a423-44ec-7ad5-4f9eba8dbb9c",
+  "manifests": {
+    "urn:c2pa:14808c4e-a423-44ec-7ad5-4f9eba8dbb9c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "bdf8ba30-2df8-07fb-997d-41edd6f8c15a",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 61,
+                "length": 1462
+              }
+            ],
+            "alg": "sha256",
+            "hash": "GcNr4sBh5+PnEBPxRE5Jho5b5puh8+ZmPESZrJZ33o8=",
+            "pad": "AAAAAAAAAAAAAAAAAA=="
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/hard_bindings_missing.jpg.crjson
+++ b/contrib/google/assets/hard_bindings_missing.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:99cb9f86-672b-881b-4aca-4d860e00e063",
+  "manifests": {
+    "urn:c2pa:99cb9f86-672b-881b-4aca-4d860e00e063": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "ac72a1ac-9a2b-9d39-8f3b-46385c17cfc5",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1366
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/hashed_uri_unresolvable.jpg.crjson
+++ b/contrib/google/assets/hashed_uri_unresolvable.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:dd2e9be4-1869-1baa-6234-4360eb3d909f",
+  "manifests": {
+    "urn:c2pa:dd2e9be4-1869-1baa-6234-4360eb3d909f": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "97dab39f-2577-f0dc-b0df-4eee8a2b629a",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1529
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ingredient_with_hard_binding_mismatch.jpg.crjson
+++ b/contrib/google/assets/ingredient_with_hard_binding_mismatch.jpg.crjson
@@ -1,0 +1,137 @@
+{
+  "active_manifest": "urn:c2pa:14a1ada5-2f96-91df-804f-42a78d9919c3",
+  "manifests": {
+    "urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "25d69552-1e97-bd6a-104e-49091bab7454",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "EANqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "urn:c2pa:14a1ada5-2f96-91df-804f-42a78d9919c3": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "fdbb9e1c-a4bd-f86e-765e-4b336ac4dc32",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 4276
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "Wurb+f6AtHAxSs+C7RmbDZxB1cOIsyGTJ4dsqx0TSd4="
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "label": "c2pa.ingredient.v3",
+          "data": {
+            "dc:format": "image/jpeg",
+            "relationship": "parentOf",
+            "validationResults": {
+              "activeManifest": {
+                "failure": [
+                  {
+                    "code": "assertion.dataHash.mismatch",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.assertions/c2pa.hash.data"
+                  }
+                ],
+                "success": [
+                  {
+                    "code": "signingCredential.trusted",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.signature"
+                  },
+                  {
+                    "code": "claimSignature.insideValidity",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.signature"
+                  },
+                  {
+                    "code": "claimSignature.validated",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.signature"
+                  },
+                  {
+                    "code": "assertion.hashedURI.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.assertions/c2pa.actions.v2"
+                  },
+                  {
+                    "code": "assertion.hashedURI.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.assertions/c2pa.hash.data"
+                  }
+                ],
+                "informational": [
+                  {
+                    "code": "signingCredential.ocsp.skipped",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.signature"
+                  }
+                ]
+              }
+            },
+            "activeManifest": {
+              "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540",
+              "hash": "hCs2ez3QFxOwUE7Pj7Hj5jeCxJ7TqCy7yZT3jE5szbU="
+            },
+            "claimSignature": {
+              "url": "self#jumbf=/c2pa/urn:c2pa:06c2b89e-84b1-cd52-c10b-4fe018168540/c2pa.signature",
+              "hash": "S2FA+sjcooE/3vavclsaxt6FnoJuh0HhLrjr1PStQYY="
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ingredient_with_missing_manifest.jpg.crjson
+++ b/contrib/google/assets/ingredient_with_missing_manifest.jpg.crjson
@@ -1,0 +1,100 @@
+{
+  "active_manifest": "urn:c2pa:a1a88b45-0ac4-e316-09f5-491f9d18dabb",
+  "manifests": {
+    "urn:c2pa:a1a88b45-0ac4-e316-09f5-491f9d18dabb": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "d9c9ae3b-0f94-c1a7-3a91-4c218004acef",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2870
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "I1qKbzlv9gcSYQQxpSW6myUFPrFfjfrAPHxjLo/82II="
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "label": "c2pa.ingredient.v3",
+          "data": {
+            "dc:format": "image/jpeg",
+            "relationship": "parentOf",
+            "validationResults": {
+              "activeManifest": {
+                "failure": [],
+                "success": [
+                  {
+                    "code": "signingCredential.trusted",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  },
+                  {
+                    "code": "claimSignature.insideValidity",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  },
+                  {
+                    "code": "claimSignature.validated",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  },
+                  {
+                    "code": "assertion.hashedURI.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.assertions/c2pa.actions.v2"
+                  },
+                  {
+                    "code": "assertion.hashedURI.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.assertions/c2pa.hash.data"
+                  },
+                  {
+                    "code": "assertion.dataHash.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.assertions/c2pa.hash.data"
+                  }
+                ],
+                "informational": [
+                  {
+                    "code": "signingCredential.ocsp.skipped",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  }
+                ]
+              }
+            },
+            "activeManifest": {
+              "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f",
+              "hash": "S7BFf545wHHAUBgnzW7PwsPXj3W3B+I75QIQkfWRwjE="
+            },
+            "claimSignature": {
+              "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature",
+              "hash": "P9UooXKmt4HLjW+bdS9FgPIhFI65Bu9iYJWPlNP/7r0="
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/issuing_ca_cert_included.jpg.crjson
+++ b/contrib/google/assets/issuing_ca_cert_included.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:8d9e9957-4e76-f813-b92c-441f56f9e2af",
+  "manifests": {
+    "urn:c2pa:8d9e9957-4e76-f813-b92c-441f56f9e2af": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "72689507-2745-e1f0-8239-48f07eb94e24",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1832
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/issuing_ca_cert_omitted.jpg.crjson
+++ b/contrib/google/assets/issuing_ca_cert_omitted.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:1d07bc39-605d-7906-ab8d-48d3053d13ee",
+  "manifests": {
+    "urn:c2pa:1d07bc39-605d-7906-ab8d-48d3053d13ee": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "5bc3a94b-1efe-a52f-fff1-4c4b535d416c",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1463
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ku_none.jpg.crjson
+++ b/contrib/google/assets/ku_none.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:2dbf8620-e689-8871-96d4-41a9377c86b9",
+  "manifests": {
+    "urn:c2pa:2dbf8620-e689-8871-96d4-41a9377c86b9": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "4f0da13d-4285-3163-17c3-4fe321754e7c",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1445
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/m4a_valid.m4a.crjson
+++ b/contrib/google/assets/m4a_valid.m4a.crjson
@@ -1,0 +1,55 @@
+{
+  "active_manifest": "urn:c2pa:e94b902a-45f6-72ff-c6f5-4c1e1f33c061",
+  "manifests": {
+    "urn:c2pa:e94b902a-45f6-72ff-c6f5-4c1e1f33c061": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "33cb80b4-6b2f-f7df-50ec-4cc518629ae6",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.bmff.v3",
+          "data": {
+            "exclusions": [
+              {
+                "xpath": "/ftyp"
+              },
+              {
+                "xpath": "/uuid",
+                "data": [
+                  {
+                    "offset": 8,
+                    "value": "2P7D1hsOSDySl1goh37EgQ=="
+                  }
+                ]
+              },
+              {
+                "xpath": "/mfra"
+              },
+              {
+                "xpath": "/free"
+              }
+            ],
+            "alg": "sha256",
+            "hash": "ZMd1yLU3Exr/xIX4bqY2gk5+/hlFgUCUMOvRFCoAY4k=",
+            "name": "BMFF file hash"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/malformed_assertion.jpg.crjson
+++ b/contrib/google/assets/malformed_assertion.jpg.crjson
@@ -1,0 +1,34 @@
+{
+  "active_manifest": "urn:c2pa:e1c88031-1072-a33b-ffb5-4beafd993366",
+  "manifests": {
+    "urn:c2pa:e1c88031-1072-a33b-ffb5-4beafd993366": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "499eb3f1-b478-e84c-69aa-4d8d23f9fed5",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {}
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/missing_created_assertions.jpg.crjson
+++ b/contrib/google/assets/missing_created_assertions.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:9d01b3c4-55bc-1d7a-5d50-40010b8dce47",
+  "manifests": {
+    "urn:c2pa:9d01b3c4-55bc-1d7a-5d50-40010b8dce47": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "f7c184aa-1d64-5db6-a5c9-427a1a38a771",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1454
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/missing_instance_id.jpg.crjson
+++ b/contrib/google/assets/missing_instance_id.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:ab1db93b-4c84-ce1e-40d3-42b60be42a2d",
+  "manifests": {
+    "urn:c2pa:ab1db93b-4c84-ce1e-40d3-42b60be42a2d": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1404
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/mov_valid.mov.crjson
+++ b/contrib/google/assets/mov_valid.mov.crjson
@@ -1,0 +1,55 @@
+{
+  "active_manifest": "urn:c2pa:3463a4b8-907a-f067-8e57-48ff332dcdf2",
+  "manifests": {
+    "urn:c2pa:3463a4b8-907a-f067-8e57-48ff332dcdf2": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "15588214-61ed-5e7c-a282-41460c85160f",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.bmff.v3",
+          "data": {
+            "exclusions": [
+              {
+                "xpath": "/ftyp"
+              },
+              {
+                "xpath": "/uuid",
+                "data": [
+                  {
+                    "offset": 8,
+                    "value": "2P7D1hsOSDySl1goh37EgQ=="
+                  }
+                ]
+              },
+              {
+                "xpath": "/mfra"
+              },
+              {
+                "xpath": "/free"
+              }
+            ],
+            "alg": "sha256",
+            "hash": "RlTQGBSsamBvZjzKjdFyIdyqqulnVBlYLE9TfgbAWf4=",
+            "name": "BMFF file hash"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/mp3_valid.mp3.crjson
+++ b/contrib/google/assets/mp3_valid.mp3.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:c5108a07-1f1d-3eb2-9a86-4e5e34f25c95",
+  "manifests": {
+    "urn:c2pa:c5108a07-1f1d-3eb2-9a86-4e5e34f25c95": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "415eb18b-d37f-6102-00be-45b67837dc10",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 63,
+                "length": 1441
+              }
+            ],
+            "alg": "sha256",
+            "hash": "MXHMfVNGzjtm2rQwQ6ihgH0gRQBl31uceA5Jdf/djRs=",
+            "pad": "AAAAAAAAAAAAAAAAAA=="
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/mp4_valid.mp4.crjson
+++ b/contrib/google/assets/mp4_valid.mp4.crjson
@@ -1,0 +1,55 @@
+{
+  "active_manifest": "urn:c2pa:5746b69c-3330-de50-cf3e-41ad64e80384",
+  "manifests": {
+    "urn:c2pa:5746b69c-3330-de50-cf3e-41ad64e80384": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "69ffa5d0-2a07-fb64-e1d0-4ecece586f24",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.bmff.v3",
+          "data": {
+            "exclusions": [
+              {
+                "xpath": "/ftyp"
+              },
+              {
+                "xpath": "/uuid",
+                "data": [
+                  {
+                    "offset": 8,
+                    "value": "2P7D1hsOSDySl1goh37EgQ=="
+                  }
+                ]
+              },
+              {
+                "xpath": "/mfra"
+              },
+              {
+                "xpath": "/free"
+              }
+            ],
+            "alg": "sha256",
+            "hash": "YmaMRPsmbKA0HzgAmRUv71Tifwkj9bPK/tafdPqo7jU=",
+            "name": "BMFF file hash"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_extra_data.jpg.crjson
+++ b/contrib/google/assets/multipart_extra_data.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b",
+  "manifests": {
+    "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6cef8fa8-8a0c-5143-711e-4df9594e5763",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_gap.jpg.crjson
+++ b/contrib/google/assets/multipart_gap.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:d931960a-2c8d-0df4-bda1-43f47a611d9a",
+  "manifests": {
+    "urn:c2pa:d931960a-2c8d-0df4-bda1-43f47a611d9a": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "77de8690-f1e3-85a3-5191-43bbfcf7f0e7",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33586
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_intact.jpg.crjson
+++ b/contrib/google/assets/multipart_intact.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b",
+  "manifests": {
+    "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6cef8fa8-8a0c-5143-711e-4df9594e5763",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_optional_part_mismatch.jpg.crjson
+++ b/contrib/google/assets/multipart_optional_part_mismatch.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b",
+  "manifests": {
+    "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6cef8fa8-8a0c-5143-711e-4df9594e5763",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_optional_part_partly_removed.jpg.crjson
+++ b/contrib/google/assets/multipart_optional_part_partly_removed.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b",
+  "manifests": {
+    "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6cef8fa8-8a0c-5143-711e-4df9594e5763",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_optional_part_removed.jpg.crjson
+++ b/contrib/google/assets/multipart_optional_part_removed.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b",
+  "manifests": {
+    "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6cef8fa8-8a0c-5143-711e-4df9594e5763",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_optional_parts_removed.jpg.crjson
+++ b/contrib/google/assets/multipart_optional_parts_removed.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b",
+  "manifests": {
+    "urn:c2pa:8b6ebacd-930e-631b-d10a-47fe7f6b280b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6cef8fa8-8a0c-5143-711e-4df9594e5763",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": true
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_required_part_intact.jpg.crjson
+++ b/contrib/google/assets/multipart_required_part_intact.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:cbf69069-b116-099f-1232-4905fa1be601",
+  "manifests": {
+    "urn:c2pa:cbf69069-b116-099f-1232-4905fa1be601": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "5c4fb919-f2bf-9b2f-4df7-4e0ae832d8aa",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/multipart_required_part_removed.jpg.crjson
+++ b/contrib/google/assets/multipart_required_part_removed.jpg.crjson
@@ -1,0 +1,113 @@
+{
+  "active_manifest": "urn:c2pa:cbf69069-b116-099f-1232-4905fa1be601",
+  "manifests": {
+    "urn:c2pa:cbf69069-b116-099f-1232-4905fa1be601": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "5c4fb919-f2bf-9b2f-4df7-4e0ae832d8aa",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.multi-asset",
+          "data": {
+            "parts": [
+              {
+                "location": {
+                  "byteOffset": 0,
+                  "length": 2708294
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part",
+                  "hash": "U2unW20001B357M6BjrTloSG8q2WG+YDRzNcyL0ie3I="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2708294,
+                  "length": 33587
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__1",
+                  "hash": "NTbpS6bYp5cCzJqJfznI97MIIpa/YOsG3aCPmxS6pwk="
+                },
+                "optional": false
+              },
+              {
+                "location": {
+                  "byteOffset": 2741881,
+                  "length": 3279811
+                },
+                "hashAssertion": {
+                  "url": "self#jumbf=c2pa.assertions/c2pa.hash.data.part__2",
+                  "hash": "oLGzXP85R6KLS3GAhhvZrGKUSQoSHIFJN5YqLBoO7xo="
+                },
+                "optional": true
+              }
+            ],
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__2",
+          "data": {
+            "alg": "sha256",
+            "hash": "baB8TKO5hGDfIxi8QJZScTop3Yi/VQP12zp5Xz/Hc/M=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part__1",
+          "data": {
+            "alg": "sha256",
+            "hash": "TbOaYmaeNW75mFKoXQH6laDA/oCeOqyCTAxncC4jxus=",
+            "pad": ""
+          }
+        },
+        {
+          "label": "c2pa.hash.data.part",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "g47xPzky8MpE8Bmhec/248KWicbYGuEVaySOH4ekt94=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 24920,
+                "length": 2808
+              }
+            ],
+            "alg": "sha256",
+            "hash": "P2nRRLkTdQvEvDf55edt/lSfuW1XsMoxPiYO7Hvf+sY=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_bad_sig.jpg.crjson
+++ b/contrib/google/assets/ocsp_bad_sig.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:15e1b523-c309-5bbc-b6b6-4c5c48005c2c",
+  "manifests": {
+    "urn:c2pa:15e1b523-c309-5bbc-b6b6-4c5c48005c2c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "8bc795e5-32e9-23ce-9e80-43c711084e61",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3052
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_expired_at_vtime.jpg.crjson
+++ b/contrib/google/assets/ocsp_expired_at_vtime.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:79298416-f536-845f-297f-492dfe6ec0eb",
+  "manifests": {
+    "urn:c2pa:79298416-f536-845f-297f-492dfe6ec0eb": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "11998200-977d-f4c2-3248-4668ccc89858",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3052
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_expired_next_update.jpg.crjson
+++ b/contrib/google/assets/ocsp_expired_next_update.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:7709888f-b46b-a85e-1211-459f63ecc2f7",
+  "manifests": {
+    "urn:c2pa:7709888f-b46b-a85e-1211-459f63ecc2f7": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "f339bf7d-8b30-d1c8-3bb0-49ed7b021b38",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3051
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_future.jpg.crjson
+++ b/contrib/google/assets/ocsp_future.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:81a3a9e1-e01b-b5e9-4ec9-4956601e1aa1",
+  "manifests": {
+    "urn:c2pa:81a3a9e1-e01b-b5e9-4ec9-4956601e1aa1": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "83fdb3c7-03c1-1875-207f-44cc3314094f",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3053
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_good.jpg.crjson
+++ b/contrib/google/assets/ocsp_good.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:6fd393fd-9f2b-3d1d-bdd2-4ed8a9285493",
+  "manifests": {
+    "urn:c2pa:6fd393fd-9f2b-3d1d-bdd2-4ed8a9285493": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "a93ab61a-da00-94e3-93ee-491efa3e379b",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3051
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_intermediate_revoked.jpg.crjson
+++ b/contrib/google/assets/ocsp_intermediate_revoked.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:d734b981-9199-e7ac-d3f0-4050f6b6f071",
+  "manifests": {
+    "urn:c2pa:d734b981-9199-e7ac-d3f0-4050f6b6f071": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "5b009d4b-4868-5f5c-446a-42d8b5da99ed",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 4092
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_no_eku.jpg.crjson
+++ b/contrib/google/assets/ocsp_no_eku.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:36ca9b83-e50b-9805-49a4-47049030f98e",
+  "manifests": {
+    "urn:c2pa:36ca9b83-e50b-9805-49a4-47049030f98e": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "488abfcc-2212-60f8-e06a-48e6b957c6f5",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3046
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_revoked.jpg.crjson
+++ b/contrib/google/assets/ocsp_revoked.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:cbf3b6cf-b3f9-d895-d321-49aa964f443a",
+  "manifests": {
+    "urn:c2pa:cbf3b6cf-b3f9-d895-d321-49aa964f443a": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6d4d997f-9fc6-932d-83ff-4af86730561a",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3070
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_unauthorized.jpg.crjson
+++ b/contrib/google/assets/ocsp_unauthorized.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:13dd9478-bacd-d28d-7f36-4ea88dc92deb",
+  "manifests": {
+    "urn:c2pa:13dd9478-bacd-d28d-7f36-4ea88dc92deb": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "ace7b527-7a06-a7f6-3ba0-449942ee217e",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3076
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ocsp_wrong_cert.jpg.crjson
+++ b/contrib/google/assets/ocsp_wrong_cert.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:d855b41d-3380-2d90-8290-4e2d2c7cdce5",
+  "manifests": {
+    "urn:c2pa:d855b41d-3380-2d90-8290-4e2d2c7cdce5": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "bf47a1ad-a458-5b29-f673-46a924233d28",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 3056
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/opened_with_ingredient.jpg.crjson
+++ b/contrib/google/assets/opened_with_ingredient.jpg.crjson
@@ -1,0 +1,137 @@
+{
+  "active_manifest": "urn:c2pa:8172b7e5-e21b-01b5-fbf0-4a59796c894f",
+  "manifests": {
+    "urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "96dabe58-cd1f-f829-a362-4658584f40b4",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "urn:c2pa:8172b7e5-e21b-01b5-fbf0-4a59796c894f": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "ad1c8b0a-aa8b-dd60-7e30-4ac14d76e38d",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 4300
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "Ji03/FuAj2k9X9RUj7lw19lJRGyQSWXpi/uGDlxiBQI="
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "label": "c2pa.ingredient.v3",
+          "data": {
+            "dc:title": "Test 1 Ingredient",
+            "dc:format": "image/jpeg",
+            "relationship": "parentOf",
+            "validationResults": {
+              "activeManifest": {
+                "failure": [],
+                "success": [
+                  {
+                    "code": "signingCredential.trusted",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  },
+                  {
+                    "code": "claimSignature.insideValidity",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  },
+                  {
+                    "code": "claimSignature.validated",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  },
+                  {
+                    "code": "assertion.hashedURI.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.assertions/c2pa.actions.v2"
+                  },
+                  {
+                    "code": "assertion.hashedURI.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.assertions/c2pa.hash.data"
+                  },
+                  {
+                    "code": "assertion.dataHash.match",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.assertions/c2pa.hash.data"
+                  }
+                ],
+                "informational": [
+                  {
+                    "code": "signingCredential.ocsp.skipped",
+                    "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature"
+                  }
+                ]
+              }
+            },
+            "activeManifest": {
+              "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f",
+              "hash": "S7BFf545wHHAUBgnzW7PwsPXj3W3B+I75QIQkfWRwjE="
+            },
+            "claimSignature": {
+              "url": "self#jumbf=/c2pa/urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f/c2pa.signature",
+              "hash": "P9UooXKmt4HLjW+bdS9FgPIhFI65Bu9iYJWPlNP/7r0="
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/pathlen_sub0_violation.jpg.crjson
+++ b/contrib/google/assets/pathlen_sub0_violation.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:c462ab33-e6c4-356e-f6b6-478dea0b2808",
+  "manifests": {
+    "urn:c2pa:c462ab33-e6c4-356e-f6b6-478dea0b2808": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "b163a592-9310-a2de-876c-44c75b9fc605",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2197
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/pathlen_sub1_ok.jpg.crjson
+++ b/contrib/google/assets/pathlen_sub1_ok.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:e90790a8-abc8-efdc-1c25-4901469bcd4b",
+  "manifests": {
+    "urn:c2pa:e90790a8-abc8-efdc-1c25-4901469bcd4b": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "12549054-30ee-44a4-b71f-4a1b48b70b4c",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2199
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/pdf_valid.pdf.crjson
+++ b/contrib/google/assets/pdf_valid.pdf.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:3b3dbff2-d24a-774b-294c-4a52090196b9",
+  "manifests": {
+    "urn:c2pa:3b3dbff2-d24a-774b-294c-4a52090196b9": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "6a978afe-4d34-e459-16f7-4ee63a1e2d26",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 6191,
+                "length": 1441
+              }
+            ],
+            "alg": "sha256",
+            "hash": "1kLATqO4GBq8dxUynEXb9b83aIFmZEve3bBXaf+qRN0=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/png_valid.png.crjson
+++ b/contrib/google/assets/png_valid.png.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:6b9db838-46cf-1765-7516-4578d511e07e",
+  "manifests": {
+    "urn:c2pa:6b9db838-46cf-1765-7516-4578d511e07e": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "4330b007-d714-15a4-24fd-4f97d52ebcf0",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 754,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "E8Weqq1SwtZPQXSo8fkLh6zG+x4OJDdrOfz9enhWMhg=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_es256.jpg.crjson
+++ b/contrib/google/assets/sig_es256.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:2164b0ff-1710-de32-202f-4d4c416a0183",
+  "manifests": {
+    "urn:c2pa:2164b0ff-1710-de32-202f-4d4c416a0183": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "a12096ad-5747-9e9b-cd7f-46c8b810185f",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1459
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_es384.jpg.crjson
+++ b/contrib/google/assets/sig_es384.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:3ebcab0a-7baa-bccd-f628-43f4857ac9f2",
+  "manifests": {
+    "urn:c2pa:3ebcab0a-7baa-bccd-f628-43f4857ac9f2": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "5a34bf65-85a2-d732-197a-4f116b679522",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1521
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_es512.jpg.crjson
+++ b/contrib/google/assets/sig_es512.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:f850af49-d505-40e3-a9fa-4bde997e847c",
+  "manifests": {
+    "urn:c2pa:f850af49-d505-40e3-a9fa-4bde997e847c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "171997d4-1566-9e09-430e-465f776453c2",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1595
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_missing.jpg.crjson
+++ b/contrib/google/assets/sig_missing.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:724aa087-2b09-4d32-85b3-46322aabb7bb",
+  "manifests": {
+    "urn:c2pa:724aa087-2b09-4d32-85b3-46322aabb7bb": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "4280a31f-4a9d-9bf6-ee9b-49ea898e14ab",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1455
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_ps256.jpg.crjson
+++ b/contrib/google/assets/sig_ps256.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:ef579589-0a1c-0533-e83e-48ee10786cff",
+  "manifests": {
+    "urn:c2pa:ef579589-0a1c-0533-e83e-48ee10786cff": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "7e3e822a-855f-ec7c-5514-41e5d2989e03",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1860
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_ps384.jpg.crjson
+++ b/contrib/google/assets/sig_ps384.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:2a678d9e-e3ee-566b-beab-44f304c4fd06",
+  "manifests": {
+    "urn:c2pa:2a678d9e-e3ee-566b-beab-44f304c4fd06": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "9ff79a63-8ffc-9a98-e16a-482af46f0fa0",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2117
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_ps512.jpg.crjson
+++ b/contrib/google/assets/sig_ps512.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:557ea379-8430-f88f-30c3-46e386d5444c",
+  "manifests": {
+    "urn:c2pa:557ea379-8430-f88f-30c3-46e386d5444c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "45b3b2f5-c2f5-59c9-4d0e-4cab0e15a2de",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2373
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/sig_uri_invalid.jpg.crjson
+++ b/contrib/google/assets/sig_uri_invalid.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:56e6a49f-c0f3-963c-56b5-47b741a54023",
+  "manifests": {
+    "urn:c2pa:56e6a49f-c0f3-963c-56b5-47b741a54023": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "72698895-c90b-ed84-667d-412ea03f0174",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1480
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/tampered_assertion.jpg.crjson
+++ b/contrib/google/assets/tampered_assertion.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:2308931b-e290-12ec-90ac-463994eb93a2",
+  "manifests": {
+    "urn:c2pa:2308931b-e290-12ec-90ac-463994eb93a2": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "45ad885e-039d-472a-09af-40373b56b58a",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/test1.jpg.crjson
+++ b/contrib/google/assets/test1.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f",
+  "manifests": {
+    "urn:c2pa:8a3484ef-3788-131d-abe1-4c21cb441b4f": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "96dabe58-cd1f-f829-a362-4658584f40b4",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/tiff_valid.tiff.crjson
+++ b/contrib/google/assets/tiff_valid.tiff.crjson
@@ -1,0 +1,46 @@
+{
+  "active_manifest": "urn:c2pa:bb74bc2e-9e96-7f5e-52bf-4008a85c80f6",
+  "manifests": {
+    "urn:c2pa:bb74bc2e-9e96-7f5e-52bf-4008a85c80f6": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "ac13bd42-8592-7cbb-23f2-431720826d0b",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 485,
+                "length": 4
+              },
+              {
+                "start": 497,
+                "length": 1480
+              }
+            ],
+            "alg": "sha256",
+            "hash": "36rn32CH8m6SWMV+ebJ8x/y1+jkHQDZYlPKNtKecLLE=",
+            "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "pad2": ""
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ts_2011_ica_2010_2012.jpg.crjson
+++ b/contrib/google/assets/ts_2011_ica_2010_2012.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:2ec988ee-66c6-0f3c-eaf3-452be3c0fea4",
+  "manifests": {
+    "urn:c2pa:2ec988ee-66c6-0f3c-eaf3-452be3c0fea4": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "2207b3f7-6818-51c2-0024-4e459bc1585e",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2753
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ts_2011_tsa_from_root1.jpg.crjson
+++ b/contrib/google/assets/ts_2011_tsa_from_root1.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:f761b2d2-0570-a7e4-b2ca-4b585197aec2",
+  "manifests": {
+    "urn:c2pa:f761b2d2-0570-a7e4-b2ca-4b585197aec2": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "afc887b9-ab64-6b55-9422-4aba8ce7a9a5",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2752
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ts_2011_tsa_no_eku.jpg.crjson
+++ b/contrib/google/assets/ts_2011_tsa_no_eku.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:e0d68737-9c66-0f77-7f46-46bb63778246",
+  "manifests": {
+    "urn:c2pa:e0d68737-9c66-0f77-7f46-46bb63778246": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "48da9311-fdf2-e7e8-0785-4e1149f35bf4",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2741
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ts_2011_valid_2010_2014.jpg.crjson
+++ b/contrib/google/assets/ts_2011_valid_2010_2014.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:61d589e3-18c1-1c00-d42d-42e0e6f91a67",
+  "manifests": {
+    "urn:c2pa:61d589e3-18c1-1c00-d42d-42e0e6f91a67": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "243d84f6-4f8f-8695-cfb6-41886ae140c0",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2754
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ts_late_signer_2010_2014.jpg.crjson
+++ b/contrib/google/assets/ts_late_signer_2010_2014.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:d76f8950-f5a0-fa8d-c25b-48014660095e",
+  "manifests": {
+    "urn:c2pa:d76f8950-f5a0-fa8d-c25b-48014660095e": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "ab358c5e-d73e-ebee-6f26-42add9383dd3",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2762
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/ts_late_tsa_2010_2014.jpg.crjson
+++ b/contrib/google/assets/ts_late_tsa_2010_2014.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:9fd48a90-6763-1ace-d71b-4c37e543bf6c",
+  "manifests": {
+    "urn:c2pa:9fd48a90-6763-1ace-d71b-4c37e543bf6c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "de898495-22c6-dd76-d46a-45d2dd3817e6",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 2753
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/unsupported_hashed_uri_algorithm.jpg.crjson
+++ b/contrib/google/assets/unsupported_hashed_uri_algorithm.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:e4f18100-e376-3697-4a60-4e678f2285e1",
+  "manifests": {
+    "urn:c2pa:e4f18100-e376-3697-4a60-4e678f2285e1": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "b0d9967e-9819-db26-6399-4441e5552b66",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1462
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/wav_valid.wav.crjson
+++ b/contrib/google/assets/wav_valid.wav.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:13278254-fe78-ae9d-d3e9-49537c3cdd4c",
+  "manifests": {
+    "urn:c2pa:13278254-fe78-ae9d-d3e9-49537c3cdd4c": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "85138b30-52ae-4cd5-d14f-45857e011eab",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 46668,
+                "length": 1441
+              }
+            ],
+            "alg": "sha256",
+            "hash": "9TJRNm3M4wUls1biJ/qFzv1Nx+LIl/A0dvjEITPCAfA=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/webp_valid.webp.crjson
+++ b/contrib/google/assets/webp_valid.webp.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:d20aaad4-464d-beb6-5818-4c1c2d36e088",
+  "manifests": {
+    "urn:c2pa:d20aaad4-464d-beb6-5818-4c1c2d36e088": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "20cd8fe4-bf94-7e74-52ed-4cbf23624d48",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 1958,
+                "length": 1441
+              }
+            ],
+            "alg": "sha256",
+            "hash": "/I4YXUQRvhDYTBBMhaR3CtAjpkEb0H+HKa/FWjvf7QI=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contrib/google/assets/wrong_signing_key.jpg.crjson
+++ b/contrib/google/assets/wrong_signing_key.jpg.crjson
@@ -1,0 +1,41 @@
+{
+  "active_manifest": "urn:c2pa:9f6f894b-f55f-3ad0-873e-46d9f4bac36d",
+  "manifests": {
+    "urn:c2pa:9f6f894b-f55f-3ad0-873e-46d9f4bac36d": {
+      "claim_generator_info": {
+        "name": "Google C2PA SDK for Android",
+        "version": ":"
+      },
+      "format": "",
+      "instance_id": "9173a2df-070e-6111-43e6-41d1ade58be2",
+      "title": "",
+      "assertions": [
+        {
+          "label": "c2pa.hash.data",
+          "data": {
+            "exclusions": [
+              {
+                "start": 2924,
+                "length": 1453
+              }
+            ],
+            "alg": "sha256",
+            "hash": "7wNqJ+xJiUGHzAXIDqY284akautIELPOqoyz/EKZ08c=",
+            "pad": "AAAAAAAAAAAAAAAA"
+          }
+        },
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# crJSON content expectations for the validator suite

**From:** Encypher (independent C2PA implementation: Rust signer + validator)
**Targets:** c2pa-org/public-testfiles PR #31 (head `8273726a8fc9`)
**Status:** draft, not yet posted.

Thanks for these test cases, they are extremely helpful. We ran our validator
through all 107 and it passed, then did a full interoperability pass over every
asset with two independent validators: ours and c2pa-rs (c2patool 0.26.68,
c2pa-rs 0.89.0).

The one gap we hit: the cases assert status codes only. A validator can emit the
right codes while mis-rendering claim or assertion content and still pass. This
PR adds a Content Credentials JSON (crJSON) sidecar next to each manifest-bearing
asset so content can be checked too.

## What this adds

`assets/<asset>.crjson`: 79 sidecars, one per manifest-bearing asset (the 16
no-manifest assets get none). Each holds the decoded manifest store: the
active-manifest URN, `claim_generator_info`, `instance_id`, and the full
`assertions` list. The assets come from the Google C2PA SDK for Android test
set, and each sidecar was checked against c2patool for active-manifest URN and
normalized assertion-label coverage wherever c2patool rendered a manifest.

## What we found

Where both validators render a manifest, the active-manifest URN agrees on every
asset.

| Result | Count |
|---|---:|
| Manifest from at least one validator | 79 |
| Rendered by both | 71 |
| active-manifest URN agreement | 71 / 71 |
| assertion label-set agreement (normalized) | 68 / 71 |
| Encypher rendered, c2pa-rs produced none | 8 |
| No manifest from either | 16 |

The 3 content deltas are ingredient cases where c2pa-rs lists ingredients under a
separate key instead of in `assertions`, a render-shape difference rather than a
content disagreement.

## Where Encypher rendered content and c2pa-rs did not

On 8 assets c2patool exited without emitting a manifest. Our validator still
rendered the manifest content, and for the defect cases reported a specific C2PA
status code. For diagnostics this provides both the content and a status code
where possible.

| Asset | c2pa-rs (c2patool 0.26.68) result | Encypher result |
|---|---|---|
| `claim_cbor_invalid.jpg` | `Error: claim could not be converted from CBOR` | rendered; `claim.cbor.invalid` |
| `claim_missing.jpg` | `Error: claim superbox not found` | rendered; `claim.missing` |
| `claim_multiple.jpg` | `Error: "c2pa" multiple claim boxes found in manifest` | rendered; `claim.multiple` |
| `hard_bindings_missing.jpg` | `Error: assertion missing: url = c2pa.hash.data` | rendered; `claim.hardBindings.missing` |
| `malformed_assertion.jpg` | `Syntax error: Unsigned integer cannot be indefinite` | rendered; `assertion.cbor.invalid` |
| `missing_created_assertions.jpg` | `Error: claim could not be converted from CBOR` | rendered; `claim.malformed` |
| `missing_instance_id.jpg` | `Error: claim could not be converted from CBOR` | rendered; `claim.malformed` |
| `docx_valid.docx` | `Error: Unsupported file type` | rendered (ZIP/OPC); collection hash validates |

Seven of these are claim, assertion, or hard-binding defect cases: c2patool exits
without emitting a manifest, while Encypher renders the content and reports the
status code shown. `docx_valid.docx` is separate. It is a valid asset, but
c2patool 0.26.68 reports the ZIP/OPC family as an unsupported file type, while our
validator reads it and validates the collection hash.

## Proposed follow-up (additive, optional)

The schema has no content slot today. We suggest an optional
`manifests[].content` reference, or the `.crjson` sidecar convention used here,
so a case can assert expected content next to its status-code expectations
without changing any existing case. The exact shape, and which fields are
normative, are yours to decide.
